### PR TITLE
Fixes the tests

### DIFF
--- a/ckanext/issues/logic/action/action.py
+++ b/ckanext/issues/logic/action/action.py
@@ -513,15 +513,15 @@ def organization_users_autocomplete(context, data_dict):
 
     users = []
     for user in query.all():
-        if isinstance(user, tuple):
+        if isinstance(user, model.User):
+            user_dict = dict(user.__dict__)
+            user_dict.pop('_labels', None)
+        else:
             user_dict = {
                 'id': user[0],
                 'name': user[1],
                 'fullname': user[2],
             }
-        else:
-            user_dict = dict(user.__dict__)
-            user_dict.pop('_labels', None)
         users.append(user_dict)
     return users
 


### PR DESCRIPTION
- Calls the function directly instead of mocking the render
- Updates the username to default instead of test.ckan.net
- Handles the user object accessing the __dict__ attribute. If the user object is a tuple, then a new user_dict variable with the id, name, and fullname attributes will be created